### PR TITLE
add a stateful=1 query parameter during login to support new ZM API

### DIFF
--- a/zoneminder.py
+++ b/zoneminder.py
@@ -59,7 +59,8 @@ def login ():
     login_url = '{base_url}/api/host/login.json'.format(base_url=_base_url)
     creds = {
                 'user': _addon.getSetting('username').strip(),
-                'pass': _addon.getSetting('password').strip()
+                'pass': _addon.getSetting('password').strip(),
+                'stateful': 1
             }
     try:
         r = requests.post(login_url, data=creds)


### PR DESCRIPTION
Resolves https://github.com/petegallagher/plugin.video.zoneminder/issues/5

https://zoneminder.readthedocs.io/en/latest/api.html#api-evolution

> Note that as of 1.34, both versions of API access will work (tokens and the older auth hash mechanism), however we no longer use sessions by default. You will have to add a stateful=1 query parameter during login to tell ZM to set a COOKIE and store the required info in the session. This option is only available if OPT_USE_LEGACY_API_AUTH is set to ON.